### PR TITLE
fix: handle invalid sunrise and sunset time

### DIFF
--- a/src/fetchDataFromURL.js
+++ b/src/fetchDataFromURL.js
@@ -99,10 +99,18 @@ async function fetchSunrise(adapter, $) {
     // Find and store value
     const sunrise = $("#sunrise-sunset-today #sunrise").text().trim();
 
-    // Create a Date object with today's date and the given time
-    const [hours, minutes] = sunrise.split(":").map(Number);
-    const now = new Date();
-    const value = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes).toISOString();
+    let value = null;
+    if (sunrise && /^\d{1,2}:\d{2}$/.test(sunrise)) {
+        const [hours, minutes] = sunrise.split(":").map((v) => parseInt(v, 10));
+        if (!isNaN(hours) && !isNaN(minutes)) {
+            const now = new Date();
+            value = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes).toISOString();
+        } else {
+            adapter.log.warn(`Invalid sunrise time received: ${sunrise}`);
+        }
+    } else if (sunrise) {
+        adapter.log.warn(`Invalid sunrise time received: ${sunrise}`);
+    }
 
     // Define object options
     const options = {
@@ -124,10 +132,18 @@ async function fetchSunset(adapter, $) {
     // Find and store value
     const sunset = $("#sunrise-sunset-today #sunset").text().trim();
 
-    // Create a Date object with today's date and the given time
-    const [hours, minutes] = sunset.split(":").map(Number);
-    const now = new Date();
-    const value = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes).toISOString();
+    let value = null;
+    if (sunset && /^\d{1,2}:\d{2}$/.test(sunset)) {
+        const [hours, minutes] = sunset.split(":").map((v) => parseInt(v, 10));
+        if (!isNaN(hours) && !isNaN(minutes)) {
+            const now = new Date();
+            value = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes).toISOString();
+        } else {
+            adapter.log.warn(`Invalid sunset time received: ${sunset}`);
+        }
+    } else if (sunset) {
+        adapter.log.warn(`Invalid sunset time received: ${sunset}`);
+    }
 
     // Define object options
     const options = {


### PR DESCRIPTION
## Summary
- avoid crashes when sunrise or sunset values are missing or malformed

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*
- `npm run check` *(fails: TypeScript CommonJS/ESM import issue in test/mocha.setup.js)*
- `npm run test:integration`


------
https://chatgpt.com/codex/tasks/task_e_68b5d05dcb50833389e497a75f700393