### PR TITLE
fix: handle invalid sunrise sunset times

### DIFF
--- a/parseTimeToISO.test.js
+++ b/parseTimeToISO.test.js
@@ -1,0 +1,26 @@
+const { expect } = require("chai");
+const { parseTimeToISO } = require("./src/fetchDataFromURL");
+
+const adapter = { log: { warn: () => {} } };
+
+describe("parseTimeToISO", () => {
+    it("returns ISO string for valid time", () => {
+        const result = parseTimeToISO(adapter, "12:34", "sunrise");
+        expect(result).to.be.a("string");
+    });
+
+    it("returns null for invalid time", () => {
+        const result = parseTimeToISO(adapter, "invalid", "sunrise");
+        expect(result).to.be.null;
+    });
+
+    it("does not throw when toISOString fails", () => {
+        const original = Date.prototype.toISOString;
+        Date.prototype.toISOString = () => {
+            throw new RangeError("Invalid time value");
+        };
+        const result = parseTimeToISO(adapter, "01:02", "sunrise");
+        expect(result).to.be.null;
+        Date.prototype.toISOString = original;
+    });
+});

--- a/src/fetchDataFromURL.js
+++ b/src/fetchDataFromURL.js
@@ -98,26 +98,35 @@ async function fetchTemperature(adapter, $) {
  * @returns {string|null} ISO timestamp or null if invalid
  */
 function parseTimeToISO(adapter, timeString, label) {
-    if (timeString && /^\d{1,2}:\d{2}$/.test(timeString)) {
-        const [hours, minutes] = timeString.split(":").map((v) => parseInt(v, 10));
+    if (!timeString) {
+        return null;
+    }
+
+    const match = timeString.match(/^(\d{1,2}):(\d{2})$/);
+    if (match) {
+        const hours = parseInt(match[1], 10);
+        const minutes = parseInt(match[2], 10);
+
         if (
-            !isNaN(hours) &&
-            !isNaN(minutes) &&
+            Number.isInteger(hours) &&
+            Number.isInteger(minutes) &&
             hours >= 0 &&
             hours < 24 &&
             minutes >= 0 &&
             minutes < 60
         ) {
             const now = new Date();
-            const date = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes);
-            if (!isNaN(date.getTime())) {
+
+            try {
+                const date = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes);
                 return date.toISOString();
+            } catch (_error) {
+                // ignore and fall through to warning below
             }
         }
-        adapter.log.warn(`Invalid ${label} time received: ${timeString}`);
-    } else if (timeString) {
-        adapter.log.warn(`Invalid ${label} time received: ${timeString}`);
     }
+
+    adapter.log.warn(`Invalid ${label} time received: ${timeString}`);
     return null;
 }
 
@@ -128,7 +137,7 @@ function parseTimeToISO(adapter, timeString, label) {
  */
 async function fetchSunrise(adapter, $) {
     // Find and store value
-    const sunrise = $("#sunrise-sunset-today #sunrise").text().trim();
+    const sunrise = $("#sunrise-sunset-today #sunrise").text().trim().split(" ")[0];
     const value = parseTimeToISO(adapter, sunrise, "sunrise");
 
     // Define object options
@@ -149,7 +158,7 @@ async function fetchSunrise(adapter, $) {
  */
 async function fetchSunset(adapter, $) {
     // Find and store value
-    const sunset = $("#sunrise-sunset-today #sunset").text().trim();
+    const sunset = $("#sunrise-sunset-today #sunset").text().trim().split(" ")[0];
     const value = parseTimeToISO(adapter, sunset, "sunset");
 
     // Define object options
@@ -635,4 +644,5 @@ async function fetchDataFromURL(adapter) {
 module.exports = {
     checkURL,
     fetchDataFromURL,
+    parseTimeToISO,
 };


### PR DESCRIPTION
## Summary
- guard against invalid sunrise/sunset time values
- add unit test for parseTimeToISO

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7274f21108333b612317b8a00577e